### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,10 +6,10 @@
 # Funções especiais (KEYWORD1)
 #######################################
 
-MRobot	KEYWORD1	MRobot
-HRobot	KEYWORD1	HRobot
-Sensor	KEYWORD1	Sensor
-Led	KEYWORD1	Led
+MRobot	KEYWORD1
+HRobot	KEYWORD1
+Sensor	KEYWORD1
+Led	KEYWORD1
 
 #######################################
 # Metodos e Funções (KEYWORD2)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format